### PR TITLE
Fallback für Kontoinhaber

### DIFF
--- a/Programm/epl_api/person.cpp
+++ b/Programm/epl_api/person.cpp
@@ -1101,7 +1101,7 @@ QString Person::getPersonaldatenFuerEinzelAlsHTML() const
         absch += help.arg("Zahler", getKontoinhaber());
     } else {
         absch += help.arg("Konto", "%2 bei %3").arg(iban, bank);
-        absch += help.arg("Kontoinhaber", getKontoinhaber());
+        absch += help.arg("Kontoinhaber", getKontoinhaberFinal());
     }
     if (absch != "")
         h += "<h3>Mitgliedschaft</h3><ul>" + absch + "</ul>";
@@ -1187,7 +1187,7 @@ QString Person::getPersonaldatenFuerListeAlsCSV() const
             +";"+toString(beitragsart)
             +";"+iban
             +";"+bank
-            +";"+getKontoinhaber()
+            +";"+getKontoinhaberFinal()
 
             +";"+(ausbildungTf ? "WAHR":"FALSCH")
             +";"+(ausbildungZf ? "WAHR":"FALSCH")
@@ -1301,6 +1301,14 @@ void Person::setBank(const QString &value)
 {
     bank = value;
     emit changed();
+}
+
+QString Person::getKontoinhaberFinal() const
+{
+    QString kI = getKontoinhaber();
+    if (kI != "")
+        return kI;
+    return getName();
 }
 
 QString Person::getKontoinhaber() const

--- a/Programm/epl_api/person.h
+++ b/Programm/epl_api/person.h
@@ -120,6 +120,7 @@ public:
     QString getBank() const;
     void setBank(const QString &value);
 
+    QString getKontoinhaberFinal() const;
     QString getKontoinhaber() const;
     void setKontoinhaber(const QString &value);
 

--- a/Programm/epl_gui/personwindow.cpp
+++ b/Programm/epl_gui/personwindow.cpp
@@ -45,14 +45,10 @@ PersonWindow::PersonWindow(CoreMainWindow *parent, Person *p) :
     ui->dateAustritt->setDate(p->getAustritt());
 
     ui->comboBeitragsart->setCurrentIndex(p->getBeitragsart());
+    on_comboBeitragsart_currentIndexChanged(ui->comboBeitragsart->currentIndex());
     ui->lineIBAN->setText(p->getIban());
     ui->lineBank->setText(p->getBank());
     ui->lineKontoinhaber->setText(p->getKontoinhaber());
-    if (p->getBeitragsart() == Person::Beitragsart::FamilienBeitragNutzer) {
-        ui->labelKonto->setText("Zahler");
-        ui->lineIBAN->setEnabled(false);
-        ui->lineBank->setEnabled(false);
-    }
 
     // Kontakt
     ui->lineStrasse->setText(p->getStrasse());
@@ -119,10 +115,9 @@ void PersonWindow::on_actionEinzelDrucken_triggered()
 void PersonWindow::on_lineVorname_textChanged(const QString &arg1)
 {
     if (enabled) {
-        // test, ob Person vorhanden ist
         if (person->setVorname(arg1)) {
             setWindowTitle(person->getName());
-            // Nichts zu tun
+            ui->lineKontoinhaber->setPlaceholderText(person->getName());
         } else {
             QMessageBox::information(this, tr("Name doppelt vergeben"), tr("Der eingegebene Namen ist bereits im System registriert.\nSomit kann keine zweite Personen den gleichen Namen haben!"));
         }
@@ -133,7 +128,7 @@ void PersonWindow::on_lineNachname_textChanged(const QString &arg1)
     if (enabled) {
         if (person->setNachname(arg1)) {
             setWindowTitle(person->getName());
-            // Nicht zu tun
+            ui->lineKontoinhaber->setPlaceholderText(person->getName());
         } else {
             QMessageBox::information(this, tr("Name doppelt vergeben"), tr("Der eingegebene Namen ist bereits im System registriert.\nSomit kann keine zweite Personen den gleichen Namen haben!"));
         }
@@ -344,9 +339,22 @@ void PersonWindow::on_comboBeitragsart_currentIndexChanged(int index)
     Person::Beitragsart ba = static_cast<Person::Beitragsart>(index);
     if (enabled)
         person->setBeitragsart(ba);
-    ui->lineIBAN->setEnabled(ba != Person::Beitragsart::FamilienBeitragNutzer);
-    ui->lineBank->setEnabled(ba != Person::Beitragsart::FamilienBeitragNutzer);
-    ui->labelKonto->setText(ba != Person::Beitragsart::FamilienBeitragNutzer? "Kontoinhaber":"Zahler");
+
+    if (ba == Person::Beitragsart::FamilienBeitragNutzer) {
+        ui->lineIBAN->setEnabled(false);
+        ui->lineBank->setEnabled(false);
+        ui->labelKonto->setText(tr("Zahler"));
+        ui->lineKontoinhaber->setPlaceholderText("");
+        ui->lineKontoinhaber->setToolTip("");
+        ui->lineKontoinhaber->setStatusTip(tr("Name der Person, die den Beitrag bezahlt."));
+    } else {
+        ui->lineIBAN->setEnabled(true);
+        ui->lineBank->setEnabled(true);
+        ui->labelKonto->setText(tr("Kontoinhaber"));
+        ui->lineKontoinhaber->setPlaceholderText(person->getName());
+        ui->lineKontoinhaber->setToolTip(tr("Name des Kontoinhabers, sofern abweichend vom Namen der Person."));
+        ui->lineKontoinhaber->setStatusTip(tr("Abweichender Kontoinhaber"));
+    }
 }
 
 void PersonWindow::on_lineIBAN_textChanged(const QString &arg1)

--- a/Programm/epl_gui/personwindow.ui
+++ b/Programm/epl_gui/personwindow.ui
@@ -510,7 +510,14 @@
          <widget class="QLineEdit" name="lineBank"/>
         </item>
         <item row="6" column="1" colspan="2">
-         <widget class="QLineEdit" name="lineKontoinhaber"/>
+         <widget class="QLineEdit" name="lineKontoinhaber">
+          <property name="toolTip">
+           <string>Name des Kontoinhabers, sofern abweichend vom Namen der Person.</string>
+          </property>
+          <property name="statusTip">
+           <string>Abweichender Kontoinhaber</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
Implementiert #114
Sofern kein Kontoinhaber angegeben ist, wird der Name der Person verwendet.
Für die Darstellung in Tabellen wird lediglich der Kontoinhaber angegeben, wenn tatsächlich ein Eintrag vorgenommen wurde.


Closes #114 